### PR TITLE
Call base class constructor correctly

### DIFF
--- a/src/BundlerApp.h
+++ b/src/BundlerApp.h
@@ -616,8 +616,7 @@ typedef std::pair<int,int> IntPair;
 class SkeletalApp : public BundlerApp
 {
 public:
-    SkeletalApp() {
-        BundlerApp::BundlerApp();
+    SkeletalApp() : BundlerApp() {
         m_start_camera = -1;
     }
 


### PR DESCRIPTION
Base constructors should be called in the initializer list rather than the body of the constructor - I think this has been fixed in the upstream bundler_src repo, but I've added the fix here because some compilers will throw a fatal error at this.